### PR TITLE
feat(auth): handle login token and logout

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -5,31 +5,43 @@ import { loginCustomer } from '../api/authApi';
 type AuthContextType = {
   login: (email: string, password: string) => Promise<boolean>;
   token: string | null;
+  logout: () => void;
 };
 
 const AuthContext = createContext<AuthContextType>({
   login: async () => false,
   token: null,
+  logout: () => {},
 });
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [token, setToken] = useState<string | null>(null);
 
-const login = async (email: string, password: string): Promise<boolean> => {
-  try {
-    console.log('🔑 Logging in with', email, password);
-    const response = await loginCustomer({ email, password });
+  const login = async (email: string, password: string): Promise<boolean> => {
+    try {
+      console.log('🔑 Logging in with', email, password);
+      const response = await loginCustomer({ email, password });
+      const receivedToken = response?.token;
 
-    console.log('✅ Login response:', response);
-    return true;
-  } catch (error) {
-    console.log('❌ Login failed', error);
-    return false;
-  }
-};
+      if (receivedToken) {
+        setToken(receivedToken);
+        console.log('✅ Login response:', response);
+        return true;
+      }
+
+      return false;
+    } catch (error) {
+      console.log('❌ Login failed', error);
+      return false;
+    }
+  };
+
+  const logout = () => {
+    setToken(null);
+  };
 
   return (
-    <AuthContext.Provider value={{ login, token }}>
+    <AuthContext.Provider value={{ login, token, logout }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- capture API token on login and store in context state
- expose logout to clear token in auth context provider

## Testing
- `npm test` *(fails: Unexpected token 'export' from @react-navigation/native)*
- `npm run lint` *(fails: 6 errors, 13 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6892520b97c4833087e3a1aa6dace14f