### PR TITLE
Handle nested token in login response

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -21,7 +21,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     try {
       console.log('🔑 Logging in with', email, password);
       const response = await loginCustomer({ email, password });
-      const receivedToken = response?.token;
+      const receivedToken =
+        response?.token ||
+        // some endpoints nest the token inside a data object
+        response?.data?.token;
 
       if (receivedToken) {
         setToken(receivedToken);


### PR DESCRIPTION
## Summary
- handle login API responses where token is nested under `data`

## Testing
- `npm test` (fails: SyntaxError: Unexpected token 'export')


------
https://chatgpt.com/codex/tasks/task_e_6892559f71a4833085dc9b7f95b3fd44