### PR TITLE
Switch to AuthScreen for login and route authenticated users to Home

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,21 +1,18 @@
 // ✅ App.tsx (wrap with AuthProvider)
 import React, { useState } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { SplashScreen } from './src/components/screens/SplashScreen';
 import { AuthScreen } from './src/components/screens/AuthScreen';
 import { HomeScreen } from './src/components/screens/HomeScreen';
 import { Navigation } from './src/components/Navigation';
 import { AuthProvider } from './src/contexts/AuthContext';
 import { StatusBar, StyleSheet, useColorScheme, View } from 'react-native';
-import LoginScreen from './src/LoginScreen';
-
-const Stack = createNativeStackNavigator();
 
 export default function App() {
   const [showSplash, setShowSplash] = useState(true);
   const [authComplete, setAuthComplete] = useState(false);
   const [currentScreen, setCurrentScreen] = useState('home');
+  const isDarkMode = useColorScheme() === 'dark';
 
   if (showSplash) {
     return <SplashScreen onComplete={() => setShowSplash(false)} />;
@@ -28,7 +25,7 @@ export default function App() {
   const renderMainScreen = () => {
     switch (currentScreen) {
       case 'home':
-        return <HomeScreen onNavigate={setCurrentScreen} />;
+        return <HomeScreen />;
       default:
         return <View />;
     }
@@ -37,11 +34,19 @@ export default function App() {
   return (
     <AuthProvider>
       <NavigationContainer>
-    <View style={styles.container}>
-      <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
-      <LoginScreen />
-    </View>
+        <View style={styles.container}>
+          <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
+          {renderMainScreen()}
+          <Navigation
+            currentScreen={currentScreen}
+            onScreenChange={setCurrentScreen}
+          />
+        </View>
       </NavigationContainer>
     </AuthProvider>
   );
 }
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   preset: 'react-native',
+  transformIgnorePatterns: [
+    'node_modules/(?!(@react-native|react-native|@react-navigation|react-native-vector-icons)/)',
+  ],
 };


### PR DESCRIPTION
## Summary
- Use `AuthScreen` instead of `LoginScreen` and gate main navigation on `authComplete`
- Allow Jest to transform navigation and icon libraries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892549769208330a8d68d3edfd040ee