### PR TITLE
feat: load products after login

### DIFF
--- a/src/api/productsApi.ts
+++ b/src/api/productsApi.ts
@@ -1,0 +1,10 @@
+export const fetchProducts = async () => {
+  try {
+    const res = await fetch('https://api.joynkins.com/api/v1/products?sort=id');
+    const json = await res.json();
+    return json.data || [];
+  } catch (err) {
+    console.error('Failed to fetch products', err);
+    return [];
+  }
+};

--- a/src/components/Home/FeaturedProducts.tsx
+++ b/src/components/Home/FeaturedProducts.tsx
@@ -1,42 +1,18 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, FlatList, Image, TouchableOpacity } from 'react-native';
-
-const products = [
-  {
-    id: '1',
-    name: 'Summer Dress',
-    price: '$89.99',
-    originalPrice: '$129.99',
-    rating: '4.8',
-    isNew: true,
-    image: 'https://images.unsplash.com/photo-1515372039744-b8f02a3ae446?w=300&h=400&fit=crop',
-  },
-  {
-    id: '2',
-    name: 'Casual Sneakers',
-    price: '$149.99',
-    rating: '4.6',
-    image: 'https://images.unsplash.com/photo-1549298916-b41d501d3772?w=300&h=400&fit=crop',
-  },
-  {
-    id: '3',
-    name: 'Designer Handbag',
-    price: '$299.99',
-    originalPrice: '$399.99',
-    rating: '4.9',
-    image: 'https://images.unsplash.com/photo-1553062407-98eeb64c6a62?w=300&h=400&fit=crop',
-  },
-  {
-    id: '4',
-    name: 'Casual T-shirt',
-    price: '$29.99',
-    rating: '4.5',
-    isNew: true,
-    image: 'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?w=300&h=400&fit=crop',
-  },
-];
+import { fetchProducts } from '../../api/productsApi';
 
 export const FeaturedProducts = () => {
+  const [products, setProducts] = useState<any[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const data = await fetchProducts();
+      setProducts(data);
+    };
+    load();
+  }, []);
+
   return (
     <View style={styles.container}>
       <View style={styles.row}>
@@ -50,15 +26,22 @@ export const FeaturedProducts = () => {
         horizontal
         data={products}
         showsHorizontalScrollIndicator={false}
-        keyExtractor={(item) => item.id}
+        keyExtractor={(item) => item.id.toString()}
         renderItem={({ item }) => (
           <View style={styles.card}>
-            <Image source={{ uri: item.image }} style={styles.image} />
-            {item.isNew && <Text style={styles.badge}>New</Text>}
+            {item?.base_image?.medium_image_url && (
+              <Image
+                source={{ uri: item.base_image.medium_image_url }}
+                style={styles.image}
+              />
+            )}
             <Text style={styles.name}>{item.name}</Text>
-            <Text style={styles.rating}>⭐ {item.rating}</Text>
-            <Text style={styles.price}>{item.price}</Text>
-            {item.originalPrice && <Text style={styles.original}>{item.originalPrice}</Text>}
+            {item?.reviews?.average_rating && (
+              <Text style={styles.rating}>⭐ {item.reviews.average_rating}</Text>
+            )}
+            <Text style={styles.price}>
+              {item.formatted_special_price || item.formatted_price}
+            </Text>
           </View>
         )}
       />
@@ -83,23 +66,7 @@ const styles = StyleSheet.create({
     elevation: 3,
   },
   image: { width: '100%', height: 100, borderRadius: 6, marginBottom: 6 },
-  badge: {
-    position: 'absolute',
-    top: 8,
-    left: 8,
-    backgroundColor: '#FF5722',
-    color: 'white',
-    fontSize: 10,
-    paddingHorizontal: 6,
-    paddingVertical: 2,
-    borderRadius: 10,
-  },
   name: { fontSize: 13, fontWeight: '600', marginTop: 4 },
   rating: { fontSize: 12, marginTop: 2 },
   price: { fontWeight: 'bold', fontSize: 14, marginTop: 2 },
-  original: {
-    fontSize: 12,
-    textDecorationLine: 'line-through',
-    color: '#999',
-  },
 });

--- a/src/components/screens/LoginScreen.tsx
+++ b/src/components/screens/LoginScreen.tsx
@@ -38,6 +38,7 @@ export const LoginScreen = ({ navigation }: Props) => {
 
       if (success) {
         Alert.alert('Login Successful');
+        navigation.replace('Home');
       } else {
         Alert.alert('Login Failed', 'Invalid credentials');
       }
@@ -56,7 +57,7 @@ export const LoginScreen = ({ navigation }: Props) => {
 
       <View style={styles.form}>
         <TextInput
-          placeholder="Email"
+          placeholder="Enter your email"
           value={email}
           onChangeText={setEmail}
           autoCapitalize="none"
@@ -65,7 +66,7 @@ export const LoginScreen = ({ navigation }: Props) => {
 
         <View style={styles.passwordWrapper}>
           <TextInput
-            placeholder="Password"
+            placeholder="Enter your password"
             secureTextEntry={!showPassword}
             value={password}
             onChangeText={setPassword}


### PR DESCRIPTION
## Summary
- show placeholders for email/password and redirect to home after login
- fetch products from backend and render on the home screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68936e26cbf483308d0cc0b0b177ab61