### PR TITLE
chore: update reanimated plugin and babel preset

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
   plugins: [
-    'react-native-reanimated/plugin', // ← keep LAST
+    'react-native-worklets/plugin', // ← keep LAST
   ],
 };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/jest": "^29.5.13",
     "@types/react": "^19.1.0",
     "@types/react-test-renderer": "^19.1.0",
+    "metro-react-native-babel-preset": "^0.77.0",
     "eslint": "^8.19.0",
     "jest": "^29.6.3",
     "prettier": "2.8.8",


### PR DESCRIPTION
## Summary
- use `react-native-worklets/plugin` in babel config
- add `metro-react-native-babel-preset` dev dependency

## Testing
- `npm test` *(fails: Cannot find module 'metro-react-native-babel-preset')*


------
https://chatgpt.com/codex/tasks/task_e_6898e642a46c8330ab7b5d34cd3c3054